### PR TITLE
feat: ポートフォリオ構成の円グラフ（DonutChart）を追加

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -74,19 +74,15 @@ body {
 
 /* Premium gradient backgrounds */
 .gradient-primary {
-  background: linear-gradient(
-    135deg,
-    var(--color-primary) 0%,
-    var(--color-primary-light) 100%
-  );
+  background: linear-gradient(135deg,
+      var(--color-primary) 0%,
+      var(--color-primary-light) 100%);
 }
 
 .gradient-accent {
-  background: linear-gradient(
-    135deg,
-    var(--color-accent) 0%,
-    var(--color-accent-light) 100%
-  );
+  background: linear-gradient(135deg,
+      var(--color-accent) 0%,
+      var(--color-accent-light) 100%);
 }
 
 .gradient-dark {
@@ -113,6 +109,13 @@ body {
   --tremor-content-emphasis: #1e293b;
   --tremor-background-muted: #f8fafc;
   --tremor-border-default: #e2e8f0;
+
+  /* Tremor Chart Colors - same as categoryConfig */
+  --tremor-indigo: #6366f1;
+  --tremor-amber: #f59e0b;
+  --tremor-emerald: #10b981;
+  --tremor-slate: #64748b;
+  --tremor-cyan: #06b6d4;
 }
 
 .dark {
@@ -223,3 +226,59 @@ body .recharts-tooltip-wrapper [class*="tremor"] {
 }
 
 /* biome-ignore-end lint: Necessary to override Tremor/Recharts styles */
+
+/* Donut Chart Color Overrides for Tremor */
+.recharts-pie-sector path[class*="fill-indigo"],
+.recharts-sector[class*="fill-indigo"] {
+  fill: #6366f1 !important;
+}
+
+.recharts-pie-sector path[class*="fill-amber"],
+.recharts-sector[class*="fill-amber"] {
+  fill: #f59e0b !important;
+}
+
+.recharts-pie-sector path[class*="fill-emerald"],
+.recharts-sector[class*="fill-emerald"] {
+  fill: #10b981 !important;
+}
+
+.recharts-pie-sector path[class*="fill-slate"],
+.recharts-sector[class*="fill-slate"] {
+  fill: #64748b !important;
+}
+
+.recharts-pie-sector path[class*="fill-cyan"],
+.recharts-sector[class*="fill-cyan"] {
+  fill: #06b6d4 !important;
+}
+
+/* Tremor DonutChart specific color overrides */
+[data-testid="pie-cell-0"] {
+  fill: #6366f1 !important;
+}
+
+[data-testid="pie-cell-1"] {
+  fill: #f59e0b !important;
+}
+
+[data-testid="pie-cell-2"] {
+  fill: #10b981 !important;
+}
+
+[data-testid="pie-cell-3"] {
+  fill: #64748b !important;
+}
+
+/* DonutChart center label - dark mode white text */
+.dark .recharts-pie-label-text,
+.dark .tremor-DonutChart-label,
+.dark [class*="tremor-DonutChart"] text,
+.dark .recharts-text.recharts-pie-label-text tspan,
+html.dark .recharts-layer text,
+html.dark svg text[class*="tremor"],
+html.dark svg text[class*="fill-dark-tremor"],
+html.dark .recharts-pie text {
+  fill: #f1f5f9 !important;
+  color: #f1f5f9 !important;
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { AreaChart } from "@/components/AreaChart";
+import { DonutChart } from "@/components/DonutChart";
 import { ThemeToggle } from "@/components/ThemeToggle";
 
 // 月次データ
@@ -472,6 +473,140 @@ export default function Home() {
               showLegend={false}
               yAxisWidth={70}
             />
+          </div>
+        </section>
+
+        {/* ポートフォリオ構成（円グラフ） */}
+        <section className="p-8 rounded-2xl bg-white dark:bg-[#1e293b] border border-[#e2e8f0] dark:border-[#334155] shadow-lg">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="w-1.5 h-8 rounded-full bg-gradient-to-b from-[#6366f1] to-[#8b5cf6]" />
+            <div>
+              <h2 className="text-xl font-bold text-[#1e293b] dark:text-white">
+                ポートフォリオ構成
+              </h2>
+              <p className="text-sm text-[#64748b] dark:text-[#94a3b8]">
+                資産カテゴリ別の配分比率
+              </p>
+            </div>
+          </div>
+
+          <div className="flex flex-col lg:flex-row items-center gap-8">
+            {/* 円グラフ */}
+            <div className="w-full lg:w-1/2 h-80">
+              <DonutChart
+                data={[
+                  { name: "日本株", value: 1350000 },
+                  { name: "米国株", value: 1600000 },
+                  { name: "投資信託", value: 1050000 },
+                  { name: "現金", value: 610000 },
+                ]}
+                colors={["indigo", "amber", "emerald", "slate"]}
+                valueFormatter={(value: number) => `¥${value.toLocaleString()}`}
+                variant="donut"
+                label="¥4,610,000"
+              />
+            </div>
+
+            {/* 詳細情報 */}
+            <div className="w-full lg:w-1/2 space-y-4">
+              <div className="p-4 rounded-xl bg-gradient-to-r from-indigo-500/10 to-indigo-500/5 border border-indigo-500/20">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-3">
+                    <div className="w-10 h-10 rounded-lg bg-indigo-500 flex items-center justify-center">
+                      <span className="text-white text-lg">🇯🇵</span>
+                    </div>
+                    <div>
+                      <p className="font-semibold text-[#1e293b] dark:text-white">
+                        日本株
+                      </p>
+                      <p className="text-sm text-[#64748b] dark:text-[#94a3b8]">
+                        国内株式
+                      </p>
+                    </div>
+                  </div>
+                  <div className="text-right">
+                    <p className="font-bold text-[#1e293b] dark:text-white">
+                      ¥1,350,000
+                    </p>
+                    <p className="text-sm text-indigo-500 font-medium">29.3%</p>
+                  </div>
+                </div>
+              </div>
+
+              <div className="p-4 rounded-xl bg-gradient-to-r from-amber-500/10 to-amber-500/5 border border-amber-500/20">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-3">
+                    <div className="w-10 h-10 rounded-lg bg-amber-500 flex items-center justify-center">
+                      <span className="text-white text-lg">🇺🇸</span>
+                    </div>
+                    <div>
+                      <p className="font-semibold text-[#1e293b] dark:text-white">
+                        米国株
+                      </p>
+                      <p className="text-sm text-[#64748b] dark:text-[#94a3b8]">
+                        米国株式
+                      </p>
+                    </div>
+                  </div>
+                  <div className="text-right">
+                    <p className="font-bold text-[#1e293b] dark:text-white">
+                      ¥1,600,000
+                    </p>
+                    <p className="text-sm text-amber-500 font-medium">34.7%</p>
+                  </div>
+                </div>
+              </div>
+
+              <div className="p-4 rounded-xl bg-gradient-to-r from-emerald-500/10 to-emerald-500/5 border border-emerald-500/20">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-3">
+                    <div className="w-10 h-10 rounded-lg bg-emerald-500 flex items-center justify-center">
+                      <span className="text-white text-lg">📊</span>
+                    </div>
+                    <div>
+                      <p className="font-semibold text-[#1e293b] dark:text-white">
+                        投資信託
+                      </p>
+                      <p className="text-sm text-[#64748b] dark:text-[#94a3b8]">
+                        ファンド
+                      </p>
+                    </div>
+                  </div>
+                  <div className="text-right">
+                    <p className="font-bold text-[#1e293b] dark:text-white">
+                      ¥1,050,000
+                    </p>
+                    <p className="text-sm text-emerald-500 font-medium">
+                      22.8%
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              <div className="p-4 rounded-xl bg-gradient-to-r from-slate-500/10 to-slate-500/5 border border-slate-500/20">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-3">
+                    <div className="w-10 h-10 rounded-lg bg-slate-500 flex items-center justify-center">
+                      <span className="text-white text-lg">💵</span>
+                    </div>
+                    <div>
+                      <p className="font-semibold text-[#1e293b] dark:text-white">
+                        現金
+                      </p>
+                      <p className="text-sm text-[#64748b] dark:text-[#94a3b8]">
+                        預金・現金
+                      </p>
+                    </div>
+                  </div>
+                  <div className="text-right">
+                    <p className="font-bold text-[#1e293b] dark:text-white">
+                      ¥610,000
+                    </p>
+                    <p className="text-sm text-slate-500 font-medium">13.2%</p>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
         </section>
       </main>

--- a/frontend/src/components/DonutChart.tsx
+++ b/frontend/src/components/DonutChart.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import type { CustomTooltipProps } from "@tremor/react";
+import { DonutChart as TremorDonutChart } from "@tremor/react";
+
+interface DonutChartData {
+  name: string;
+  value: number;
+}
+
+interface DonutChartProps {
+  className?: string;
+  data: DonutChartData[];
+  colors?: string[];
+  valueFormatter?: (value: number) => string;
+  showAnimation?: boolean;
+  variant?: "pie" | "donut";
+  label?: string;
+}
+
+// カラーマッピング（AreaChartと統一）
+const colorMap: Record<string, string> = {
+  indigo: "#6366f1",
+  amber: "#f59e0b",
+  emerald: "#10b981",
+  slate: "#64748b",
+  cyan: "#06b6d4",
+};
+
+// カスタムツールチップコンポーネント（AreaChartと統一したスタイル）
+const CustomTooltip = ({ payload, active }: CustomTooltipProps) => {
+  if (!active || !payload || payload.length === 0) return null;
+
+  const entry = payload[0];
+  const entryColor = String(entry.color || "");
+  const color = colorMap[entryColor] || entryColor || "#6366f1";
+  const name = String(entry.name || "");
+  const value = Number(entry.value || 0);
+
+  return (
+    <div className="rounded-xl border border-[#334155] bg-[#1e293b] p-4 shadow-2xl">
+      <div className="flex items-center justify-between gap-8">
+        <div className="flex items-center gap-2">
+          <span
+            className="w-3 h-3 rounded-full"
+            style={{ backgroundColor: color }}
+          />
+          <span className="text-sm text-white font-medium">{name}</span>
+        </div>
+        <span className="text-sm font-bold text-white">
+          ¥{value.toLocaleString("ja-JP")}
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export function DonutChart({
+  className,
+  data,
+  colors = ["indigo", "amber", "emerald", "slate"],
+  valueFormatter,
+  showAnimation = true,
+  variant = "donut",
+  label,
+}: DonutChartProps) {
+  return (
+    <div className={`flex items-center justify-center ${className || ""}`}>
+      <TremorDonutChart
+        data={data}
+        category="value"
+        index="name"
+        colors={colors}
+        valueFormatter={valueFormatter}
+        showAnimation={showAnimation}
+        variant={variant}
+        label={label}
+        className="h-64 w-64"
+        customTooltip={CustomTooltip}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
- DonutChartコンポーネントを新規作成（Tremor使用）
- 日本株、米国株、投資信託、現金の資産配分を円グラフで表示
- 資産推移チャートと同じ配色に統一（indigo, amber, emerald, slate）
- ホバー時のツールチップをAreaChartと同じダークスタイルに統一
- ダークモード時の中央ラベル（金額）を白色に修正