### PR TITLE
docs: バックエンド API ドキュメントを日本語化

### DIFF
--- a/.agent/workflows/database-setup.md
+++ b/.agent/workflows/database-setup.md
@@ -1,0 +1,71 @@
+---
+description: データベースのセットアップとマイグレーション手順
+---
+
+# Database Setup Workflow
+
+## 前提条件
+- Docker Desktop が起動していること
+
+## 手順
+
+### 1. PostgreSQL を起動
+```bash
+docker compose up -d db
+```
+
+### 2. Backend コンテナを起動（Alembic 実行用）
+```bash
+docker compose up -d backend
+```
+
+### 3. マイグレーションを実行
+```bash
+docker compose exec backend alembic upgrade head
+```
+
+### 4. デモデータを投入
+```bash
+docker compose exec backend python -m app.seed
+```
+
+### 5. データ確認（オプション）
+```bash
+# テーブル一覧
+docker compose exec db psql -U postgres -d appdb -c "\dt"
+
+# スナップショット数
+docker compose exec db psql -U postgres -d appdb -c "SELECT COUNT(*) FROM asset_snapshots;"
+
+# 貯金目標
+docker compose exec db psql -U postgres -d appdb -c "SELECT * FROM savings_goals;"
+```
+
+### 6. pgAdmin でアクセス（オプション）
+```bash
+docker compose up -d pgadmin
+```
+- URL: http://localhost:5050
+- Email: admin@admin.com
+- Password: admin
+- DB Host: db
+- DB User/Password: postgres/postgres
+
+## トラブルシューティング
+
+### Alembic バージョンエラーが発生した場合
+```bash
+# alembic_version テーブルをリセット
+docker compose exec db psql -U postgres -d appdb -c "DROP TABLE IF EXISTS alembic_version CASCADE;"
+
+# 再度マイグレーション
+docker compose exec backend alembic upgrade head
+```
+
+### すべてリセットしたい場合
+```bash
+docker compose down -v
+docker compose up -d db backend
+docker compose exec backend alembic upgrade head
+docker compose exec backend python -m app.seed
+```

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -14,6 +14,7 @@ from alembic import context
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+from app import models  # noqa: F401 - Import models for autogenerate
 from app.database import Base, settings
 
 # this is the Alembic Config object, which provides

--- a/backend/alembic/versions/001_initial_schema.py
+++ b/backend/alembic/versions/001_initial_schema.py
@@ -1,0 +1,161 @@
+"""Initial schema with all tables
+
+Revision ID: 001_initial_schema
+Revises:
+Create Date: 2025-12-29
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "001_initial_schema"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Enable UUID extension
+    op.execute('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"')
+
+    # Create asset_categories table
+    op.create_table(
+        "asset_categories",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("name", sa.String(length=50), nullable=False),
+        sa.Column("name_en", sa.String(length=50), nullable=False),
+        sa.Column("color", sa.String(length=20), nullable=False),
+        sa.Column("icon", sa.String(length=50), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("name"),
+    )
+
+    # Create assets table
+    op.create_table(
+        "assets",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("uuid_generate_v4()"),
+            nullable=False,
+        ),
+        sa.Column("category_id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("ticker_symbol", sa.String(length=50), nullable=True),
+        sa.Column("quantity", sa.Numeric(precision=18, scale=4), nullable=False, default=0),
+        sa.Column("average_cost", sa.Numeric(precision=18, scale=2), nullable=True),
+        sa.Column("current_price", sa.Numeric(precision=18, scale=2), nullable=True),
+        sa.Column("current_value", sa.Numeric(precision=18, scale=2), nullable=True),
+        sa.Column("currency", sa.String(length=3), nullable=False, default="JPY"),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.text("NOW()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.text("NOW()"), nullable=False),
+        sa.ForeignKeyConstraint(["category_id"], ["asset_categories.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("idx_assets_category_id", "assets", ["category_id"])
+
+    # Create asset_histories table
+    op.create_table(
+        "asset_histories",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("uuid_generate_v4()"),
+            nullable=False,
+        ),
+        sa.Column("asset_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("record_date", sa.Date(), nullable=False),
+        sa.Column("price", sa.Numeric(precision=18, scale=2), nullable=True),
+        sa.Column("value", sa.Numeric(precision=18, scale=2), nullable=False),
+        sa.Column("quantity", sa.Numeric(precision=18, scale=4), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.text("NOW()"), nullable=False),
+        sa.ForeignKeyConstraint(["asset_id"], ["assets.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("asset_id", "record_date", name="uq_asset_history_date"),
+    )
+    op.create_index("idx_asset_histories_asset_id", "asset_histories", ["asset_id"])
+    op.create_index("idx_asset_histories_record_date", "asset_histories", ["record_date"])
+
+    # Create asset_snapshots table
+    op.create_table(
+        "asset_snapshots",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("uuid_generate_v4()"),
+            nullable=False,
+        ),
+        sa.Column("snapshot_date", sa.Date(), nullable=False),
+        sa.Column("total_assets", sa.Numeric(precision=18, scale=2), nullable=False),
+        sa.Column(
+            "japanese_stocks",
+            sa.Numeric(precision=18, scale=2),
+            nullable=False,
+            default=0,
+        ),
+        sa.Column("us_stocks", sa.Numeric(precision=18, scale=2), nullable=False, default=0),
+        sa.Column(
+            "investment_trusts",
+            sa.Numeric(precision=18, scale=2),
+            nullable=False,
+            default=0,
+        ),
+        sa.Column("cash", sa.Numeric(precision=18, scale=2), nullable=False, default=0),
+        sa.Column("holding_count", sa.Integer(), nullable=False, default=0),
+        sa.Column("yield_rate", sa.Numeric(precision=5, scale=2), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.text("NOW()"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("snapshot_date"),
+    )
+    op.create_index("idx_asset_snapshots_snapshot_date", "asset_snapshots", ["snapshot_date"])
+
+    # Create savings_goals table
+    op.create_table(
+        "savings_goals",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("uuid_generate_v4()"),
+            nullable=False,
+        ),
+        sa.Column("label", sa.String(length=100), nullable=False),
+        sa.Column("target_amount", sa.Numeric(precision=18, scale=2), nullable=False),
+        sa.Column(
+            "current_amount",
+            sa.Numeric(precision=18, scale=2),
+            nullable=False,
+            default=0,
+        ),
+        sa.Column("target_date", sa.Date(), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, default=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.text("NOW()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.text("NOW()"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # Insert initial asset categories
+    op.execute("""
+        INSERT INTO asset_categories (name, name_en, color, icon) VALUES
+        ('日本株', 'japanese_stocks', 'indigo', 'Building2'),
+        ('米国株', 'us_stocks', 'amber', 'Globe'),
+        ('投資信託', 'investment_trusts', 'emerald', 'TrendingUp'),
+        ('現金', 'cash', 'slate', 'Wallet')
+    """)
+
+
+def downgrade() -> None:
+    op.drop_table("savings_goals")
+    op.drop_index("idx_asset_snapshots_snapshot_date", table_name="asset_snapshots")
+    op.drop_table("asset_snapshots")
+    op.drop_index("idx_asset_histories_record_date", table_name="asset_histories")
+    op.drop_index("idx_asset_histories_asset_id", table_name="asset_histories")
+    op.drop_table("asset_histories")
+    op.drop_index("idx_assets_category_id", table_name="assets")
+    op.drop_table("assets")
+    op.drop_table("asset_categories")

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,1 @@
+# Solo Saving Backend App

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,0 +1,69 @@
+"""
+Database configuration and session management.
+"""
+
+import os
+from typing import AsyncGenerator
+
+from pydantic_settings import BaseSettings
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Settings(BaseSettings):
+    """Application settings loaded from environment variables."""
+
+    POSTGRES_HOST: str = os.getenv("POSTGRES_HOST", "localhost")
+    POSTGRES_USER: str = os.getenv("POSTGRES_USER", "postgres")
+    POSTGRES_PASSWORD: str = os.getenv("POSTGRES_PASSWORD", "postgres")
+    POSTGRES_DB: str = os.getenv("POSTGRES_DB", "appdb")
+    POSTGRES_PORT: int = int(os.getenv("POSTGRES_PORT", "5432"))
+
+    @property
+    def DATABASE_URL(self) -> str:
+        """Generate async database URL for asyncpg."""
+        return (
+            f"postgresql+asyncpg://{self.POSTGRES_USER}:{self.POSTGRES_PASSWORD}"
+            f"@{self.POSTGRES_HOST}:{self.POSTGRES_PORT}/{self.POSTGRES_DB}"
+        )
+
+    class Config:
+        env_file = ".env"
+        extra = "ignore"
+
+
+settings = Settings()
+
+
+class Base(DeclarativeBase):
+    """SQLAlchemy declarative base class."""
+
+    pass
+
+
+# Create async engine
+engine = create_async_engine(
+    settings.DATABASE_URL,
+    echo=True,  # Set to False in production
+    future=True,
+)
+
+# Create async session factory
+async_session_maker = async_sessionmaker(
+    engine,
+    class_=AsyncSession,
+    expire_on_commit=False,
+)
+
+
+async def get_db() -> AsyncGenerator[AsyncSession, None]:
+    """Dependency for getting async database session."""
+    async with async_session_maker() as session:
+        try:
+            yield session
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
+        finally:
+            await session.close()

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,159 @@
+"""
+SQLAlchemy models for Solo Saving application.
+"""
+
+import uuid
+from datetime import date, datetime
+from decimal import Decimal
+
+from sqlalchemy import (
+    Boolean,
+    Date,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    Numeric,
+    String,
+    UniqueConstraint,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+
+class AssetCategory(Base):
+    """Asset category master table (日本株, 米国株, 投資信託, 現金)."""
+
+    __tablename__ = "asset_categories"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(50), unique=True, nullable=False)
+    name_en: Mapped[str] = mapped_column(String(50), nullable=False)
+    color: Mapped[str] = mapped_column(String(20), nullable=False)
+    icon: Mapped[str | None] = mapped_column(String(50), nullable=True)
+
+    # Relationships
+    assets: Mapped[list["Asset"]] = relationship("Asset", back_populates="category")
+
+    def __repr__(self) -> str:
+        return f"<AssetCategory(id={self.id}, name='{self.name}')>"
+
+
+class Asset(Base):
+    """Individual asset (stock, fund, cash, etc.)."""
+
+    __tablename__ = "assets"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    category_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("asset_categories.id"), nullable=False
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    ticker_symbol: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    quantity: Mapped[Decimal] = mapped_column(Numeric(18, 4), nullable=False, default=Decimal("0"))
+    average_cost: Mapped[Decimal | None] = mapped_column(Numeric(18, 2), nullable=True)
+    current_price: Mapped[Decimal | None] = mapped_column(Numeric(18, 2), nullable=True)
+    current_value: Mapped[Decimal | None] = mapped_column(Numeric(18, 2), nullable=True)
+    currency: Mapped[str] = mapped_column(String(3), nullable=False, default="JPY")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+
+    # Relationships
+    category: Mapped["AssetCategory"] = relationship("AssetCategory", back_populates="assets")
+    histories: Mapped[list["AssetHistory"]] = relationship(
+        "AssetHistory", back_populates="asset", cascade="all, delete-orphan"
+    )
+
+    __table_args__ = (Index("idx_assets_category_id", "category_id"),)
+
+    def __repr__(self) -> str:
+        return f"<Asset(id={self.id}, name='{self.name}')>"
+
+
+class AssetHistory(Base):
+    """Historical record of asset value/price per day."""
+
+    __tablename__ = "asset_histories"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    asset_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("assets.id", ondelete="CASCADE"), nullable=False
+    )
+    record_date: Mapped[date] = mapped_column(Date, nullable=False)
+    price: Mapped[Decimal | None] = mapped_column(Numeric(18, 2), nullable=True)
+    value: Mapped[Decimal] = mapped_column(Numeric(18, 2), nullable=False)
+    quantity: Mapped[Decimal | None] = mapped_column(Numeric(18, 4), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+
+    # Relationships
+    asset: Mapped["Asset"] = relationship("Asset", back_populates="histories")
+
+    __table_args__ = (
+        UniqueConstraint("asset_id", "record_date", name="uq_asset_history_date"),
+        Index("idx_asset_histories_asset_id", "asset_id"),
+        Index("idx_asset_histories_record_date", "record_date"),
+    )
+
+    def __repr__(self) -> str:
+        return f"<AssetHistory(id={self.id}, record_date={self.record_date})>"
+
+
+class AssetSnapshot(Base):
+    """Daily snapshot of total assets by category (for charts)."""
+
+    __tablename__ = "asset_snapshots"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    snapshot_date: Mapped[date] = mapped_column(Date, unique=True, nullable=False)
+    total_assets: Mapped[Decimal] = mapped_column(Numeric(18, 2), nullable=False)
+    japanese_stocks: Mapped[Decimal] = mapped_column(
+        Numeric(18, 2), nullable=False, default=Decimal("0")
+    )
+    us_stocks: Mapped[Decimal] = mapped_column(Numeric(18, 2), nullable=False, default=Decimal("0"))
+    investment_trusts: Mapped[Decimal] = mapped_column(
+        Numeric(18, 2), nullable=False, default=Decimal("0")
+    )
+    cash: Mapped[Decimal] = mapped_column(Numeric(18, 2), nullable=False, default=Decimal("0"))
+    holding_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    yield_rate: Mapped[Decimal | None] = mapped_column(Numeric(5, 2), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+
+    __table_args__ = (Index("idx_asset_snapshots_snapshot_date", "snapshot_date"),)
+
+    def __repr__(self) -> str:
+        return f"<AssetSnapshot(id={self.id}, date={self.snapshot_date})>"
+
+
+class SavingsGoal(Base):
+    """Savings goal configuration."""
+
+    __tablename__ = "savings_goals"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    label: Mapped[str] = mapped_column(String(100), nullable=False)
+    target_amount: Mapped[Decimal] = mapped_column(Numeric(18, 2), nullable=False)
+    current_amount: Mapped[Decimal] = mapped_column(
+        Numeric(18, 2), nullable=False, default=Decimal("0")
+    )
+    target_date: Mapped[date | None] = mapped_column(Date, nullable=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+
+    def __repr__(self) -> str:
+        return f"<SavingsGoal(id={self.id}, label='{self.label}')>"

--- a/backend/app/routers.py
+++ b/backend/app/routers.py
@@ -1,0 +1,760 @@
+"""
+Solo Saving API ルーター
+
+各機能ごとに分割されたAPIエンドポイントを定義します。
+- 資産カテゴリ: マスタデータの取得
+- 資産: 個別銘柄のCRUD操作
+- スナップショット: チャート表示用の日次データ
+- 貯金目標: 目標設定と進捗管理
+- ダッシュボード: 統計情報とポートフォリオ
+"""
+
+from datetime import date, timedelta
+from decimal import Decimal
+from typing import Literal
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.database import get_db
+from app.models import Asset, AssetCategory, AssetSnapshot, SavingsGoal
+from app.schemas import (
+    AssetCategoryResponse,
+    AssetCreate,
+    AssetResponse,
+    AssetSnapshotChartData,
+    AssetSnapshotCreate,
+    AssetSnapshotResponse,
+    AssetUpdate,
+    DashboardStats,
+    PortfolioItem,
+    SavingsGoalCreate,
+    SavingsGoalResponse,
+    SavingsGoalUpdate,
+)
+
+# ============================================
+# 資産カテゴリ ルーター
+# マスタデータ（日本株、米国株、投資信託、現金）の取得
+# ============================================
+categories_router = APIRouter(
+    prefix="/api/categories",
+    tags=["資産カテゴリ"],
+)
+
+
+@categories_router.get(
+    "",
+    response_model=list[AssetCategoryResponse],
+    summary="カテゴリ一覧取得",
+    description="すべての資産カテゴリを取得します。",
+)
+async def get_categories(db: AsyncSession = Depends(get_db)):
+    """
+    資産カテゴリの一覧を取得。
+
+    Returns:
+        カテゴリ一覧（日本株、米国株、投資信託、現金）
+    """
+    result = await db.execute(select(AssetCategory).order_by(AssetCategory.id))
+    return result.scalars().all()
+
+
+# ============================================
+# 資産 ルーター
+# 個別銘柄の登録・更新・削除・取得
+# ============================================
+assets_router = APIRouter(
+    prefix="/api/assets",
+    tags=["資産"],
+)
+
+
+@assets_router.get(
+    "",
+    response_model=list[AssetResponse],
+    summary="資産一覧取得",
+    description="すべての資産を取得します。カテゴリIDで絞り込み可能。",
+)
+async def get_assets(
+    category_id: int | None = Query(
+        default=None,
+        description="カテゴリIDで絞り込み（1: 日本株, 2: 米国株, 3: 投資信託, 4: 現金）",
+    ),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    資産一覧を取得。
+
+    Args:
+        category_id: カテゴリIDで絞り込み（オプション）
+
+    Returns:
+        資産一覧（作成日時の降順）
+    """
+    query = select(Asset).options(selectinload(Asset.category))
+    if category_id:
+        query = query.where(Asset.category_id == category_id)
+    query = query.order_by(Asset.created_at.desc())
+    result = await db.execute(query)
+    return result.scalars().all()
+
+
+@assets_router.get(
+    "/{asset_id}",
+    response_model=AssetResponse,
+    summary="資産詳細取得",
+    description="指定されたIDの資産を取得します。",
+)
+async def get_asset(
+    asset_id: UUID,
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    単一の資産を取得。
+
+    Args:
+        asset_id: 資産ID（UUID）
+
+    Returns:
+        資産情報
+
+    Raises:
+        404: 資産が見つからない場合
+    """
+    result = await db.execute(
+        select(Asset).options(selectinload(Asset.category)).where(Asset.id == asset_id)
+    )
+    asset = result.scalar_one_or_none()
+    if not asset:
+        raise HTTPException(status_code=404, detail="資産が見つかりません")
+    return asset
+
+
+@assets_router.post(
+    "",
+    response_model=AssetResponse,
+    status_code=201,
+    summary="資産登録",
+    description="新しい資産を登録します。",
+)
+async def create_asset(
+    asset_data: AssetCreate,
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    新しい資産を作成。
+
+    Args:
+        asset_data: 資産作成データ
+
+    Returns:
+        作成された資産情報
+    """
+    asset = Asset(**asset_data.model_dump())
+    db.add(asset)
+    await db.flush()
+    await db.refresh(asset, ["category"])
+    return asset
+
+
+@assets_router.put(
+    "/{asset_id}",
+    response_model=AssetResponse,
+    summary="資産更新",
+    description="既存の資産を更新します。",
+)
+async def update_asset(
+    asset_id: UUID,
+    asset_data: AssetUpdate,
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    既存の資産を更新。
+
+    Args:
+        asset_id: 資産ID（UUID）
+        asset_data: 更新データ（変更するフィールドのみ）
+
+    Returns:
+        更新された資産情報
+
+    Raises:
+        404: 資産が見つからない場合
+    """
+    result = await db.execute(select(Asset).where(Asset.id == asset_id))
+    asset = result.scalar_one_or_none()
+    if not asset:
+        raise HTTPException(status_code=404, detail="資産が見つかりません")
+
+    update_data = asset_data.model_dump(exclude_unset=True)
+    for field, value in update_data.items():
+        setattr(asset, field, value)
+
+    await db.flush()
+    await db.refresh(asset, ["category"])
+    return asset
+
+
+@assets_router.delete(
+    "/{asset_id}",
+    status_code=204,
+    summary="資産削除",
+    description="指定された資産を削除します。",
+)
+async def delete_asset(
+    asset_id: UUID,
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    資産を削除。
+
+    Args:
+        asset_id: 資産ID（UUID）
+
+    Raises:
+        404: 資産が見つからない場合
+    """
+    result = await db.execute(select(Asset).where(Asset.id == asset_id))
+    asset = result.scalar_one_or_none()
+    if not asset:
+        raise HTTPException(status_code=404, detail="資産が見つかりません")
+    await db.delete(asset)
+
+
+# ============================================
+# スナップショット ルーター
+# 日次の資産スナップショット（チャート表示用データ）
+# ============================================
+snapshots_router = APIRouter(
+    prefix="/api/snapshots",
+    tags=["スナップショット"],
+)
+
+
+@snapshots_router.get(
+    "",
+    response_model=list[AssetSnapshotResponse],
+    summary="スナップショット一覧取得",
+    description="資産スナップショットを取得します。日付で絞り込み可能。",
+)
+async def get_snapshots(
+    start_date: date | None = Query(
+        default=None,
+        description="開始日（この日以降のデータを取得）",
+    ),
+    end_date: date | None = Query(
+        default=None,
+        description="終了日（この日以前のデータを取得）",
+    ),
+    limit: int = Query(
+        default=30,
+        le=365,
+        description="取得件数（最大365件）",
+    ),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    スナップショット一覧を取得。
+
+    Args:
+        start_date: 開始日フィルター
+        end_date: 終了日フィルター
+        limit: 取得件数上限
+
+    Returns:
+        スナップショット一覧（日付の降順）
+    """
+    query = select(AssetSnapshot)
+    if start_date:
+        query = query.where(AssetSnapshot.snapshot_date >= start_date)
+    if end_date:
+        query = query.where(AssetSnapshot.snapshot_date <= end_date)
+    query = query.order_by(AssetSnapshot.snapshot_date.desc()).limit(limit)
+    result = await db.execute(query)
+    return result.scalars().all()
+
+
+@snapshots_router.get(
+    "/chart",
+    response_model=list[AssetSnapshotChartData],
+    summary="チャートデータ取得",
+    description="チャート表示用のデータを取得します。日/月/年で集計期間を選択可能。",
+)
+async def get_chart_data(
+    period: Literal["day", "month", "year"] = Query(
+        default="month",
+        description="集計期間: day（直近30日）, month（直近12ヶ月）, year（直近5年）",
+    ),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    チャート表示用の集計データを取得。
+
+    Args:
+        period: 集計期間
+            - "day": 直近30日の日次データ
+            - "month": 直近12ヶ月の月末データ
+            - "year": 直近5年の年末データ
+
+    Returns:
+        チャート用データ（日本株、米国株、投資信託、現金、合計）
+    """
+    today = date.today()
+
+    if period == "day":
+        # 日次データ - 直近30日
+        start_date = today - timedelta(days=30)
+        query = (
+            select(AssetSnapshot)
+            .where(AssetSnapshot.snapshot_date >= start_date)
+            .order_by(AssetSnapshot.snapshot_date)
+        )
+        result = await db.execute(query)
+        snapshots = result.scalars().all()
+
+        return [
+            AssetSnapshotChartData(
+                date=s.snapshot_date.strftime("%m/%d"),
+                日本株=s.japanese_stocks,
+                米国株=s.us_stocks,
+                投資信託=s.investment_trusts,
+                現金=s.cash,
+                合計=s.total_assets,
+            )
+            for s in snapshots
+        ]
+
+    elif period == "month":
+        # 月次データ - 直近12ヶ月の月末データ
+        start_date = today.replace(day=1) - timedelta(days=365)
+        query = select(AssetSnapshot).where(AssetSnapshot.snapshot_date >= start_date)
+        result = await db.execute(query)
+        snapshots = result.scalars().all()
+
+        # 各月の最終日を抽出
+        monthly_data: dict[str, AssetSnapshot] = {}
+        for s in snapshots:
+            month_key = s.snapshot_date.strftime("%Y-%m")
+            if (
+                month_key not in monthly_data
+                or s.snapshot_date > monthly_data[month_key].snapshot_date
+            ):
+                monthly_data[month_key] = s
+
+        sorted_months = sorted(monthly_data.keys())
+        return [
+            AssetSnapshotChartData(
+                date=f"{int(monthly_data[m].snapshot_date.month)}月",
+                日本株=monthly_data[m].japanese_stocks,
+                米国株=monthly_data[m].us_stocks,
+                投資信託=monthly_data[m].investment_trusts,
+                現金=monthly_data[m].cash,
+                合計=monthly_data[m].total_assets,
+            )
+            for m in sorted_months[-12:]
+        ]
+
+    else:  # year
+        # 年次データ - 直近5年の年末データ
+        start_year = today.year - 5
+        query = select(AssetSnapshot).where(AssetSnapshot.snapshot_date >= date(start_year, 1, 1))
+        result = await db.execute(query)
+        snapshots = result.scalars().all()
+
+        # 各年の最終日を抽出
+        yearly_data: dict[int, AssetSnapshot] = {}
+        for s in snapshots:
+            year = s.snapshot_date.year
+            if year not in yearly_data or s.snapshot_date > yearly_data[year].snapshot_date:
+                yearly_data[year] = s
+
+        sorted_years = sorted(yearly_data.keys())
+        return [
+            AssetSnapshotChartData(
+                date=str(year),
+                日本株=yearly_data[year].japanese_stocks,
+                米国株=yearly_data[year].us_stocks,
+                投資信託=yearly_data[year].investment_trusts,
+                現金=yearly_data[year].cash,
+                合計=yearly_data[year].total_assets,
+            )
+            for year in sorted_years[-5:]
+        ]
+
+
+@snapshots_router.post(
+    "",
+    response_model=AssetSnapshotResponse,
+    status_code=201,
+    summary="スナップショット登録",
+    description="新しいスナップショットを登録します。同一日付は重複不可。",
+)
+async def create_snapshot(
+    snapshot_data: AssetSnapshotCreate,
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    新しいスナップショットを作成。
+
+    Args:
+        snapshot_data: スナップショット作成データ
+
+    Returns:
+        作成されたスナップショット
+
+    Raises:
+        400: 同一日付のスナップショットが既に存在する場合
+    """
+    # 同一日付の重複チェック
+    result = await db.execute(
+        select(AssetSnapshot).where(AssetSnapshot.snapshot_date == snapshot_data.snapshot_date)
+    )
+    existing = result.scalar_one_or_none()
+    if existing:
+        raise HTTPException(
+            status_code=400,
+            detail=f"{snapshot_data.snapshot_date} のスナップショットは既に存在します",
+        )
+
+    snapshot = AssetSnapshot(**snapshot_data.model_dump())
+    db.add(snapshot)
+    await db.flush()
+    await db.refresh(snapshot)
+    return snapshot
+
+
+@snapshots_router.get(
+    "/latest",
+    response_model=AssetSnapshotResponse | None,
+    summary="最新スナップショット取得",
+    description="最新のスナップショットを取得します。",
+)
+async def get_latest_snapshot(db: AsyncSession = Depends(get_db)):
+    """
+    最新のスナップショットを取得。
+
+    Returns:
+        最新のスナップショット（存在しない場合は null）
+    """
+    result = await db.execute(
+        select(AssetSnapshot).order_by(AssetSnapshot.snapshot_date.desc()).limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
+# ============================================
+# 貯金目標 ルーター
+# 目標金額と進捗の管理
+# ============================================
+goals_router = APIRouter(
+    prefix="/api/goals",
+    tags=["貯金目標"],
+)
+
+
+@goals_router.get(
+    "",
+    response_model=list[SavingsGoalResponse],
+    summary="貯金目標一覧取得",
+    description="貯金目標の一覧を取得します。",
+)
+async def get_goals(
+    active_only: bool = Query(
+        default=True,
+        description="アクティブな目標のみ取得",
+    ),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    貯金目標の一覧を取得。
+
+    Args:
+        active_only: Trueの場合、アクティブな目標のみ取得
+
+    Returns:
+        貯金目標一覧（作成日時の降順）
+    """
+    query = select(SavingsGoal)
+    if active_only:
+        query = query.where(SavingsGoal.is_active == True)  # noqa: E712
+    query = query.order_by(SavingsGoal.created_at.desc())
+    result = await db.execute(query)
+    return result.scalars().all()
+
+
+@goals_router.get(
+    "/{goal_id}",
+    response_model=SavingsGoalResponse,
+    summary="貯金目標詳細取得",
+    description="指定されたIDの貯金目標を取得します。",
+)
+async def get_goal(
+    goal_id: UUID,
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    単一の貯金目標を取得。
+
+    Args:
+        goal_id: 目標ID（UUID）
+
+    Returns:
+        貯金目標情報
+
+    Raises:
+        404: 目標が見つからない場合
+    """
+    result = await db.execute(select(SavingsGoal).where(SavingsGoal.id == goal_id))
+    goal = result.scalar_one_or_none()
+    if not goal:
+        raise HTTPException(status_code=404, detail="貯金目標が見つかりません")
+    return goal
+
+
+@goals_router.post(
+    "",
+    response_model=SavingsGoalResponse,
+    status_code=201,
+    summary="貯金目標登録",
+    description="新しい貯金目標を登録します。",
+)
+async def create_goal(
+    goal_data: SavingsGoalCreate,
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    新しい貯金目標を作成。
+
+    Args:
+        goal_data: 目標作成データ
+
+    Returns:
+        作成された貯金目標
+    """
+    goal = SavingsGoal(**goal_data.model_dump())
+    db.add(goal)
+    await db.flush()
+    await db.refresh(goal)
+    return goal
+
+
+@goals_router.put(
+    "/{goal_id}",
+    response_model=SavingsGoalResponse,
+    summary="貯金目標更新",
+    description="既存の貯金目標を更新します。",
+)
+async def update_goal(
+    goal_id: UUID,
+    goal_data: SavingsGoalUpdate,
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    貯金目標を更新。
+
+    Args:
+        goal_id: 目標ID（UUID）
+        goal_data: 更新データ（変更するフィールドのみ）
+
+    Returns:
+        更新された貯金目標
+
+    Raises:
+        404: 目標が見つからない場合
+    """
+    result = await db.execute(select(SavingsGoal).where(SavingsGoal.id == goal_id))
+    goal = result.scalar_one_or_none()
+    if not goal:
+        raise HTTPException(status_code=404, detail="貯金目標が見つかりません")
+
+    update_data = goal_data.model_dump(exclude_unset=True)
+    for field, value in update_data.items():
+        setattr(goal, field, value)
+
+    await db.flush()
+    await db.refresh(goal)
+    return goal
+
+
+@goals_router.delete(
+    "/{goal_id}",
+    status_code=204,
+    summary="貯金目標削除",
+    description="指定された貯金目標を削除します。",
+)
+async def delete_goal(
+    goal_id: UUID,
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    貯金目標を削除。
+
+    Args:
+        goal_id: 目標ID（UUID）
+
+    Raises:
+        404: 目標が見つからない場合
+    """
+    result = await db.execute(select(SavingsGoal).where(SavingsGoal.id == goal_id))
+    goal = result.scalar_one_or_none()
+    if not goal:
+        raise HTTPException(status_code=404, detail="貯金目標が見つかりません")
+    await db.delete(goal)
+
+
+# ============================================
+# ダッシュボード ルーター
+# 統計情報とポートフォリオ構成
+# ============================================
+dashboard_router = APIRouter(
+    prefix="/api/dashboard",
+    tags=["ダッシュボード"],
+)
+
+
+@dashboard_router.get(
+    "/stats",
+    response_model=DashboardStats,
+    summary="統計情報取得",
+    description="ダッシュボードに表示する統計情報を取得します。",
+)
+async def get_dashboard_stats(db: AsyncSession = Depends(get_db)):
+    """
+    ダッシュボードの統計情報を取得。
+
+    以下の情報を返します:
+    - 総資産額と前月比の増減率
+    - 保有銘柄数と前月比の増減
+    - 利回りと前月比の増減
+
+    Returns:
+        統計情報
+    """
+    # 最新のスナップショットを取得
+    latest_result = await db.execute(
+        select(AssetSnapshot).order_by(AssetSnapshot.snapshot_date.desc()).limit(1)
+    )
+    latest = latest_result.scalar_one_or_none()
+
+    # 前月のスナップショットを取得（トレンド計算用）
+    today = date.today()
+    last_month = today.replace(day=1) - timedelta(days=1)
+    prev_result = await db.execute(
+        select(AssetSnapshot)
+        .where(AssetSnapshot.snapshot_date <= last_month)
+        .order_by(AssetSnapshot.snapshot_date.desc())
+        .limit(1)
+    )
+    prev = prev_result.scalar_one_or_none()
+
+    # データがない場合のデフォルト値
+    if not latest:
+        return DashboardStats(
+            total_assets=Decimal("0"),
+            total_assets_trend="+0%",
+            holding_count=0,
+            holding_count_trend="+0",
+            yield_rate=None,
+            yield_rate_trend="+0%",
+        )
+
+    # トレンド（前月比）を計算
+    total_trend = "+0%"
+    holding_trend = "+0"
+    yield_trend = "+0%"
+
+    if prev:
+        # 総資産の増減率
+        if prev.total_assets > 0:
+            pct = ((latest.total_assets - prev.total_assets) / prev.total_assets) * 100
+            total_trend = f"{'+' if pct >= 0 else ''}{pct:.1f}%"
+
+        # 保有銘柄数の増減
+        holding_diff = latest.holding_count - prev.holding_count
+        holding_trend = f"{'+' if holding_diff >= 0 else ''}{holding_diff}銘柄"
+
+        # 利回りの増減
+        if prev.yield_rate and latest.yield_rate:
+            yield_diff = latest.yield_rate - prev.yield_rate
+            yield_trend = f"{'+' if yield_diff >= 0 else ''}{yield_diff:.2f}%"
+
+    return DashboardStats(
+        total_assets=latest.total_assets,
+        total_assets_trend=total_trend,
+        holding_count=latest.holding_count,
+        holding_count_trend=holding_trend,
+        yield_rate=latest.yield_rate,
+        yield_rate_trend=yield_trend,
+    )
+
+
+@dashboard_router.get(
+    "/portfolio",
+    response_model=list[PortfolioItem],
+    summary="ポートフォリオ構成取得",
+    description="円グラフ表示用のポートフォリオ構成を取得します。",
+)
+async def get_portfolio(db: AsyncSession = Depends(get_db)):
+    """
+    ポートフォリオ構成を取得（円グラフ用）。
+
+    最新のスナップショットから各カテゴリの割合を計算します。
+
+    Returns:
+        ポートフォリオアイテムのリスト（名前、金額、割合、色、アイコン）
+    """
+    # 最新のスナップショットを取得
+    result = await db.execute(
+        select(AssetSnapshot).order_by(AssetSnapshot.snapshot_date.desc()).limit(1)
+    )
+    snapshot = result.scalar_one_or_none()
+
+    if not snapshot:
+        return []
+
+    total = snapshot.total_assets
+    if total == 0:
+        return []
+
+    # カテゴリ情報を取得
+    categories_result = await db.execute(select(AssetCategory))
+    categories = {c.name_en: c for c in categories_result.scalars().all()}
+
+    # ポートフォリオアイテムを作成
+    portfolio = [
+        PortfolioItem(
+            name="日本株",
+            value=snapshot.japanese_stocks,
+            percentage=(snapshot.japanese_stocks / total) * 100,
+            color=categories.get("japanese_stocks", AssetCategory(color="indigo")).color,
+            icon=categories.get("japanese_stocks", AssetCategory(icon="Building2")).icon,
+        ),
+        PortfolioItem(
+            name="米国株",
+            value=snapshot.us_stocks,
+            percentage=(snapshot.us_stocks / total) * 100,
+            color=categories.get("us_stocks", AssetCategory(color="amber")).color,
+            icon=categories.get("us_stocks", AssetCategory(icon="Globe")).icon,
+        ),
+        PortfolioItem(
+            name="投資信託",
+            value=snapshot.investment_trusts,
+            percentage=(snapshot.investment_trusts / total) * 100,
+            color=categories.get("investment_trusts", AssetCategory(color="emerald")).color,
+            icon=categories.get("investment_trusts", AssetCategory(icon="TrendingUp")).icon,
+        ),
+        PortfolioItem(
+            name="現金",
+            value=snapshot.cash,
+            percentage=(snapshot.cash / total) * 100,
+            color=categories.get("cash", AssetCategory(color="slate")).color,
+            icon=categories.get("cash", AssetCategory(icon="Wallet")).icon,
+        ),
+    ]
+
+    # 金額が0より大きいもののみ返す
+    return [p for p in portfolio if p.value > 0]

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,0 +1,376 @@
+"""
+Pydantic スキーマ定義
+
+API のリクエスト/レスポンスのバリデーションを行うスキーマ。
+各スキーマは対応するSQLAlchemyモデルと連携します。
+"""
+
+from datetime import date, datetime
+from decimal import Decimal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+# ============================================
+# 資産カテゴリ スキーマ
+# カテゴリマスタ（日本株、米国株、投資信託、現金）
+# ============================================
+class AssetCategoryBase(BaseModel):
+    """資産カテゴリの基本スキーマ"""
+
+    name: str = Field(
+        ...,
+        max_length=50,
+        description="カテゴリ名（日本語）",
+        json_schema_extra={"example": "日本株"},
+    )
+    name_en: str = Field(
+        ...,
+        max_length=50,
+        description="カテゴリ名（英語）",
+        json_schema_extra={"example": "japanese_stocks"},
+    )
+    color: str = Field(
+        ...,
+        max_length=20,
+        description="チャート表示色",
+        json_schema_extra={"example": "indigo"},
+    )
+    icon: str | None = Field(
+        None,
+        max_length=50,
+        description="アイコン名（Lucide React）",
+        json_schema_extra={"example": "Building2"},
+    )
+
+
+class AssetCategoryResponse(AssetCategoryBase):
+    """資産カテゴリのレスポンススキーマ"""
+
+    id: int = Field(..., description="カテゴリID")
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+# ============================================
+# 資産 スキーマ
+# 個別の資産（銘柄）
+# ============================================
+class AssetBase(BaseModel):
+    """資産の基本スキーマ"""
+
+    category_id: int = Field(
+        ...,
+        description="カテゴリID（1: 日本株, 2: 米国株, 3: 投資信託, 4: 現金）",
+        json_schema_extra={"example": 1},
+    )
+    name: str = Field(
+        ...,
+        max_length=255,
+        description="資産名（銘柄名など）",
+        json_schema_extra={"example": "トヨタ自動車"},
+    )
+    ticker_symbol: str | None = Field(
+        None,
+        max_length=50,
+        description="ティッカーシンボル",
+        json_schema_extra={"example": "7203"},
+    )
+    quantity: Decimal = Field(
+        default=Decimal("0"),
+        description="保有数量",
+        json_schema_extra={"example": 100},
+    )
+    average_cost: Decimal | None = Field(
+        None,
+        description="平均取得単価（円）",
+        json_schema_extra={"example": 2500.00},
+    )
+    current_price: Decimal | None = Field(
+        None,
+        description="現在価格（円）",
+        json_schema_extra={"example": 2800.00},
+    )
+    current_value: Decimal | None = Field(
+        None,
+        description="現在評価額（円）",
+        json_schema_extra={"example": 280000.00},
+    )
+    currency: str = Field(
+        default="JPY",
+        max_length=3,
+        description="通貨コード",
+        json_schema_extra={"example": "JPY"},
+    )
+
+
+class AssetCreate(AssetBase):
+    """資産作成用スキーマ"""
+
+    pass
+
+
+class AssetUpdate(BaseModel):
+    """資産更新用スキーマ（部分更新対応）"""
+
+    category_id: int | None = Field(None, description="カテゴリID")
+    name: str | None = Field(None, max_length=255, description="資産名")
+    ticker_symbol: str | None = Field(None, max_length=50, description="ティッカーシンボル")
+    quantity: Decimal | None = Field(None, description="保有数量")
+    average_cost: Decimal | None = Field(None, description="平均取得単価")
+    current_price: Decimal | None = Field(None, description="現在価格")
+    current_value: Decimal | None = Field(None, description="現在評価額")
+    currency: str | None = Field(None, max_length=3, description="通貨コード")
+
+
+class AssetResponse(AssetBase):
+    """資産のレスポンススキーマ"""
+
+    id: UUID = Field(..., description="資産ID（UUID）")
+    created_at: datetime = Field(..., description="作成日時")
+    updated_at: datetime = Field(..., description="更新日時")
+    category: AssetCategoryResponse | None = Field(None, description="カテゴリ情報")
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+# ============================================
+# 資産履歴 スキーマ
+# 日次の価格・評価額履歴
+# ============================================
+class AssetHistoryBase(BaseModel):
+    """資産履歴の基本スキーマ"""
+
+    asset_id: UUID = Field(..., description="資産ID（UUID）")
+    record_date: date = Field(
+        ...,
+        description="記録日",
+        json_schema_extra={"example": "2024-12-25"},
+    )
+    price: Decimal | None = Field(None, description="その日の価格")
+    value: Decimal = Field(..., description="その日の評価額")
+    quantity: Decimal | None = Field(None, description="その日の保有数量")
+
+
+class AssetHistoryCreate(AssetHistoryBase):
+    """資産履歴作成用スキーマ"""
+
+    pass
+
+
+class AssetHistoryResponse(AssetHistoryBase):
+    """資産履歴のレスポンススキーマ"""
+
+    id: UUID = Field(..., description="履歴ID（UUID）")
+    created_at: datetime = Field(..., description="作成日時")
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+# ============================================
+# 資産スナップショット スキーマ
+# チャート表示用の日次集計データ
+# ============================================
+class AssetSnapshotBase(BaseModel):
+    """資産スナップショットの基本スキーマ"""
+
+    snapshot_date: date = Field(
+        ...,
+        description="スナップショット日付",
+        json_schema_extra={"example": "2024-12-25"},
+    )
+    total_assets: Decimal = Field(
+        ...,
+        description="総資産額",
+        json_schema_extra={"example": 4610000},
+    )
+    japanese_stocks: Decimal = Field(
+        default=Decimal("0"),
+        description="日本株合計",
+        json_schema_extra={"example": 1350000},
+    )
+    us_stocks: Decimal = Field(
+        default=Decimal("0"),
+        description="米国株合計",
+        json_schema_extra={"example": 1600000},
+    )
+    investment_trusts: Decimal = Field(
+        default=Decimal("0"),
+        description="投資信託合計",
+        json_schema_extra={"example": 1050000},
+    )
+    cash: Decimal = Field(
+        default=Decimal("0"),
+        description="現金合計",
+        json_schema_extra={"example": 610000},
+    )
+    holding_count: int = Field(
+        default=0,
+        description="保有銘柄数",
+        json_schema_extra={"example": 12},
+    )
+    yield_rate: Decimal | None = Field(
+        None,
+        description="利回り（%）",
+        json_schema_extra={"example": 3.24},
+    )
+
+
+class AssetSnapshotCreate(AssetSnapshotBase):
+    """スナップショット作成用スキーマ"""
+
+    pass
+
+
+class AssetSnapshotResponse(AssetSnapshotBase):
+    """スナップショットのレスポンススキーマ"""
+
+    id: UUID = Field(..., description="スナップショットID（UUID）")
+    created_at: datetime = Field(..., description="作成日時")
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AssetSnapshotChartData(BaseModel):
+    """チャート表示用データスキーマ（日/月/年切り替え対応）"""
+
+    date: str = Field(
+        ...,
+        description="表示用日付文字列",
+        json_schema_extra={"example": "12月"},
+    )
+    日本株: Decimal = Field(..., description="日本株の金額")
+    米国株: Decimal = Field(..., description="米国株の金額")
+    投資信託: Decimal = Field(..., description="投資信託の金額")
+    現金: Decimal = Field(..., description="現金の金額")
+    合計: Decimal = Field(..., description="合計金額")
+
+
+# ============================================
+# 貯金目標 スキーマ
+# 目標金額と進捗管理
+# ============================================
+class SavingsGoalBase(BaseModel):
+    """貯金目標の基本スキーマ"""
+
+    label: str = Field(
+        ...,
+        max_length=100,
+        description="目標ラベル",
+        json_schema_extra={"example": "目標資産額"},
+    )
+    target_amount: Decimal = Field(
+        ...,
+        description="目標金額",
+        json_schema_extra={"example": 10000000},
+    )
+    current_amount: Decimal = Field(
+        default=Decimal("0"),
+        description="現在金額",
+        json_schema_extra={"example": 4610000},
+    )
+    target_date: date | None = Field(
+        None,
+        description="目標達成予定日",
+        json_schema_extra={"example": "2025-12-31"},
+    )
+    is_active: bool = Field(
+        default=True,
+        description="アクティブフラグ",
+    )
+
+
+class SavingsGoalCreate(SavingsGoalBase):
+    """貯金目標作成用スキーマ"""
+
+    pass
+
+
+class SavingsGoalUpdate(BaseModel):
+    """貯金目標更新用スキーマ（部分更新対応）"""
+
+    label: str | None = Field(None, max_length=100, description="目標ラベル")
+    target_amount: Decimal | None = Field(None, description="目標金額")
+    current_amount: Decimal | None = Field(None, description="現在金額")
+    target_date: date | None = Field(None, description="目標達成予定日")
+    is_active: bool | None = Field(None, description="アクティブフラグ")
+
+
+class SavingsGoalResponse(SavingsGoalBase):
+    """貯金目標のレスポンススキーマ"""
+
+    id: UUID = Field(..., description="目標ID（UUID）")
+    created_at: datetime = Field(..., description="作成日時")
+    updated_at: datetime = Field(..., description="更新日時")
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+# ============================================
+# ダッシュボード スキーマ
+# 統計情報とポートフォリオ
+# ============================================
+class DashboardStats(BaseModel):
+    """ダッシュボード統計情報スキーマ"""
+
+    total_assets: Decimal = Field(
+        ...,
+        description="総資産額",
+        json_schema_extra={"example": 4610000},
+    )
+    total_assets_trend: str = Field(
+        ...,
+        description="総資産の前月比",
+        json_schema_extra={"example": "+5.2%"},
+    )
+    holding_count: int = Field(
+        ...,
+        description="保有銘柄数",
+        json_schema_extra={"example": 12},
+    )
+    holding_count_trend: str = Field(
+        ...,
+        description="銘柄数の前月比",
+        json_schema_extra={"example": "+2銘柄"},
+    )
+    yield_rate: Decimal | None = Field(
+        None,
+        description="利回り（%）",
+        json_schema_extra={"example": 3.24},
+    )
+    yield_rate_trend: str = Field(
+        ...,
+        description="利回りの前月比",
+        json_schema_extra={"example": "+0.5%"},
+    )
+
+
+class PortfolioItem(BaseModel):
+    """ポートフォリオ構成アイテム（円グラフ用）"""
+
+    name: str = Field(
+        ...,
+        description="カテゴリ名",
+        json_schema_extra={"example": "日本株"},
+    )
+    value: Decimal = Field(
+        ...,
+        description="金額",
+        json_schema_extra={"example": 1350000},
+    )
+    percentage: Decimal = Field(
+        ...,
+        description="割合（%）",
+        json_schema_extra={"example": 29.3},
+    )
+    color: str = Field(
+        ...,
+        description="表示色",
+        json_schema_extra={"example": "indigo"},
+    )
+    icon: str | None = Field(
+        None,
+        description="アイコン名",
+        json_schema_extra={"example": "Building2"},
+    )

--- a/backend/app/seed.py
+++ b/backend/app/seed.py
@@ -1,0 +1,288 @@
+"""
+Seed script to populate database with initial/demo data.
+Run this after migrations to set up demo data matching frontend mockData.
+"""
+
+import asyncio
+from datetime import date, timedelta
+from decimal import Decimal
+
+from sqlalchemy import select
+
+from app.database import async_session_maker
+from app.models import AssetSnapshot, SavingsGoal
+
+
+async def seed_savings_goals():
+    """Seed savings goals matching appConfig.json."""
+    async with async_session_maker() as session:
+        # Check if already seeded
+        result = await session.execute(select(SavingsGoal))
+        existing = result.scalars().first()
+        if existing:
+            print("Savings goals already seeded, skipping...")
+            return
+
+        goal = SavingsGoal(
+            label="目標資産額",
+            target_amount=Decimal("10000000"),
+            current_amount=Decimal("4610000"),
+            is_active=True,
+        )
+        session.add(goal)
+        await session.commit()
+        print("✓ Seeded savings goals")
+
+
+async def seed_asset_snapshots():
+    """Seed asset snapshots matching mockData.ts."""
+    async with async_session_maker() as session:
+        # Check if already seeded
+        result = await session.execute(select(AssetSnapshot))
+        existing = result.scalars().first()
+        if existing:
+            print("Asset snapshots already seeded, skipping...")
+            return
+
+        # Monthly data from mockData.ts (2024年のデータとして)
+        monthly_data = [
+            {
+                "month": 1,
+                "日本株": 890000,
+                "米国株": 1200000,
+                "投資信託": 800000,
+                "現金": 500000,
+            },
+            {
+                "month": 2,
+                "日本株": 920000,
+                "米国株": 1150000,
+                "投資信託": 820000,
+                "現金": 510000,
+            },
+            {
+                "month": 3,
+                "日本株": 980000,
+                "米国株": 1300000,
+                "投資信託": 850000,
+                "現金": 520000,
+            },
+            {
+                "month": 4,
+                "日本株": 1050000,
+                "米国株": 1280000,
+                "投資信託": 880000,
+                "現金": 530000,
+            },
+            {
+                "month": 5,
+                "日本株": 1100000,
+                "米国株": 1350000,
+                "投資信託": 900000,
+                "現金": 540000,
+            },
+            {
+                "month": 6,
+                "日本株": 1080000,
+                "米国株": 1400000,
+                "投資信託": 920000,
+                "現金": 550000,
+            },
+            {
+                "month": 7,
+                "日本株": 1150000,
+                "米国株": 1450000,
+                "投資信託": 950000,
+                "現金": 560000,
+            },
+            {
+                "month": 8,
+                "日本株": 1120000,
+                "米国株": 1380000,
+                "投資信託": 970000,
+                "現金": 570000,
+            },
+            {
+                "month": 9,
+                "日本株": 1180000,
+                "米国株": 1420000,
+                "投資信託": 990000,
+                "現金": 580000,
+            },
+            {
+                "month": 10,
+                "日本株": 1220000,
+                "米国株": 1500000,
+                "投資信託": 1010000,
+                "現金": 590000,
+            },
+            {
+                "month": 11,
+                "日本株": 1280000,
+                "米国株": 1550000,
+                "投資信託": 1030000,
+                "現金": 600000,
+            },
+            {
+                "month": 12,
+                "日本株": 1350000,
+                "米国株": 1600000,
+                "投資信託": 1050000,
+                "現金": 610000,
+            },
+        ]
+
+        year = 2024
+        snapshots = []
+
+        for data in monthly_data:
+            # Use last day of each month
+            if data["month"] == 12:
+                snapshot_date = date(year, 12, 31)
+            else:
+                snapshot_date = date(year, data["month"] + 1, 1) - timedelta(days=1)
+
+            total = data["日本株"] + data["米国株"] + data["投資信託"] + data["現金"]
+
+            snapshot = AssetSnapshot(
+                snapshot_date=snapshot_date,
+                total_assets=Decimal(str(total)),
+                japanese_stocks=Decimal(str(data["日本株"])),
+                us_stocks=Decimal(str(data["米国株"])),
+                investment_trusts=Decimal(str(data["投資信託"])),
+                cash=Decimal(str(data["現金"])),
+                holding_count=12,  # From appConfig.dashboard.stats.holdings
+                yield_rate=Decimal("3.24"),  # From appConfig.dashboard.stats.yield
+            )
+            snapshots.append(snapshot)
+
+        # Also add some historical yearly data (2020-2023)
+        yearly_data = [
+            {
+                "year": 2020,
+                "日本株": 650000,
+                "米国株": 800000,
+                "投資信託": 500000,
+                "現金": 400000,
+            },
+            {
+                "year": 2021,
+                "日本株": 780000,
+                "米国株": 950000,
+                "投資信託": 620000,
+                "現金": 450000,
+            },
+            {
+                "year": 2022,
+                "日本株": 850000,
+                "米国株": 1100000,
+                "投資信託": 720000,
+                "現金": 480000,
+            },
+            {
+                "year": 2023,
+                "日本株": 1100000,
+                "米国株": 1350000,
+                "投資信託": 880000,
+                "現金": 550000,
+            },
+        ]
+
+        for data in yearly_data:
+            snapshot_date = date(data["year"], 12, 31)
+            total = data["日本株"] + data["米国株"] + data["投資信託"] + data["現金"]
+
+            snapshot = AssetSnapshot(
+                snapshot_date=snapshot_date,
+                total_assets=Decimal(str(total)),
+                japanese_stocks=Decimal(str(data["日本株"])),
+                us_stocks=Decimal(str(data["米国株"])),
+                investment_trusts=Decimal(str(data["投資信託"])),
+                cash=Decimal(str(data["現金"])),
+                holding_count=10,
+                yield_rate=Decimal("2.80"),
+            )
+            snapshots.append(snapshot)
+
+        # Add some daily data for December 2024
+        daily_data = [
+            {
+                "day": 1,
+                "日本株": 1300000,
+                "米国株": 1550000,
+                "投資信託": 1020000,
+                "現金": 600000,
+            },
+            {
+                "day": 5,
+                "日本株": 1310000,
+                "米国株": 1560000,
+                "投資信託": 1025000,
+                "現金": 602000,
+            },
+            {
+                "day": 10,
+                "日本株": 1320000,
+                "米国株": 1555000,
+                "投資信託": 1030000,
+                "現金": 604000,
+            },
+            {
+                "day": 15,
+                "日本株": 1335000,
+                "米国株": 1580000,
+                "投資信託": 1040000,
+                "現金": 606000,
+            },
+            {
+                "day": 20,
+                "日本株": 1340000,
+                "米国株": 1590000,
+                "投資信託": 1045000,
+                "現金": 608000,
+            },
+            {
+                "day": 25,
+                "日本株": 1350000,
+                "米国株": 1600000,
+                "投資信託": 1050000,
+                "現金": 610000,
+            },
+        ]
+
+        for data in daily_data:
+            # Skip if date already exists (e.g., Dec 31)
+            snapshot_date = date(2024, 12, data["day"])
+            existing = [s for s in snapshots if s.snapshot_date == snapshot_date]
+            if existing:
+                continue
+
+            total = data["日本株"] + data["米国株"] + data["投資信託"] + data["現金"]
+
+            snapshot = AssetSnapshot(
+                snapshot_date=snapshot_date,
+                total_assets=Decimal(str(total)),
+                japanese_stocks=Decimal(str(data["日本株"])),
+                us_stocks=Decimal(str(data["米国株"])),
+                investment_trusts=Decimal(str(data["投資信託"])),
+                cash=Decimal(str(data["現金"])),
+                holding_count=12,
+                yield_rate=Decimal("3.24"),
+            )
+            snapshots.append(snapshot)
+
+        session.add_all(snapshots)
+        await session.commit()
+        print(f"✓ Seeded {len(snapshots)} asset snapshots")
+
+
+async def main():
+    """Run all seed functions."""
+    print("Starting database seed...")
+    await seed_savings_goals()
+    await seed_asset_snapshots()
+    print("✓ Database seeding complete!")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -20,8 +20,10 @@ dev = [
 ]
 
 [tool.ruff]
-line-length = 88
+line-length = 100
 target-version = "py312"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "B"]
+# B008: FastAPI の Depends(), Query() パターンで誤検知するため除外
+ignore = ["B008"]

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1,27 +1,127 @@
+"""
+Solo Saving API - メインアプリケーションエントリーポイント
+
+このファイルはFastAPIアプリケーションの設定とルーターの登録を行います。
+"""
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from app.routers import (
+    assets_router,
+    categories_router,
+    dashboard_router,
+    goals_router,
+    snapshots_router,
+)
+
+# ==============================================
+# FastAPI アプリケーション設定
+# ==============================================
 app = FastAPI(
     title="Solo Saving API",
-    description="Personal finance management API",
+    description="""
+## 個人資産管理 API
+
+Solo Saving は個人の資産を管理・可視化するためのAPIです。
+
+### 主な機能
+
+* **資産カテゴリ** - 日本株、米国株、投資信託、現金などのカテゴリ管理
+* **資産管理** - 個別銘柄の登録・更新・削除
+* **スナップショット** - 日次の資産推移データ
+* **貯金目標** - 目標金額と進捗の管理
+* **ダッシュボード** - 統計情報とポートフォリオ構成
+
+### 技術スタック
+
+* FastAPI + SQLAlchemy (非同期)
+* PostgreSQL
+* Pydantic v2
+    """,
     version="0.1.0",
+    docs_url="/docs",
+    redoc_url="/redoc",
+    openapi_tags=[
+        {
+            "name": "資産カテゴリ",
+            "description": "資産カテゴリ（日本株、米国株、投資信託、現金）のマスタデータ",
+        },
+        {
+            "name": "資産",
+            "description": "個別資産（銘柄）の CRUD 操作",
+        },
+        {
+            "name": "スナップショット",
+            "description": "日次の資産スナップショット（チャート表示用）",
+        },
+        {
+            "name": "貯金目標",
+            "description": "貯金目標の設定と進捗管理",
+        },
+        {
+            "name": "ダッシュボード",
+            "description": "統計情報とポートフォリオ構成の取得",
+        },
+    ],
 )
 
-# CORS設定
+# ==============================================
+# CORS（クロスオリジンリソース共有）設定
+# フロントエンド（localhost:3000）からのアクセスを許可
+# ==============================================
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000"],
+    allow_origins=["http://localhost:3000"],  # フロントエンドのURL
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["*"],  # すべてのHTTPメソッドを許可
+    allow_headers=["*"],  # すべてのヘッダーを許可
 )
 
+# ==============================================
+# ルーターの登録
+# 各機能ごとにルーターを分割して管理
+# ==============================================
+app.include_router(categories_router)
+app.include_router(assets_router)
+app.include_router(snapshots_router)
+app.include_router(goals_router)
+app.include_router(dashboard_router)
 
-@app.get("/")
+
+# ==============================================
+# ヘルスチェックエンドポイント
+# ==============================================
+@app.get(
+    "/",
+    summary="ルートエンドポイント",
+    description="APIが稼働しているかを確認するためのエンドポイント",
+    tags=["ヘルスチェック"],
+)
 async def root():
-    return {"message": "Solo Saving API is running"}
+    """
+    APIのルートエンドポイント。
+
+    Returns:
+        APIが稼働中であることを示すメッセージ
+    """
+    return {"message": "Solo Saving API is running", "status": "ok"}
 
 
-@app.get("/health")
+@app.get(
+    "/health",
+    summary="ヘルスチェック",
+    description="アプリケーションの状態を確認",
+    tags=["ヘルスチェック"],
+)
 async def health():
+    """
+    ヘルスチェックエンドポイント。
+
+    ロードバランサーやモニタリングツールから
+    アプリケーションの稼働状態を確認するために使用。
+
+    Returns:
+        ステータスOKを示すJSON
+    """
     return {"status": "ok"}

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -1,0 +1,310 @@
+# データベース設計書
+
+## 概要
+
+Solo Saving アプリケーションのPostgreSQLデータベース設計書です。
+
+- **DBMS**: PostgreSQL 15
+- **設計方針**: シングルユーザー前提
+- **テーブル数**: 5テーブル
+
+---
+
+## ER図
+
+```mermaid
+erDiagram
+    assets ||--o{ asset_histories : tracks
+    asset_categories ||--o{ assets : categorizes
+
+    asset_categories {
+        serial id PK "カテゴリID"
+        varchar_50 name UK "カテゴリ名（日本語）"
+        varchar_50 name_en "カテゴリ名（英語）"
+        varchar_20 color "チャート表示色"
+        varchar_50 icon "アイコン名"
+    }
+
+    assets {
+        uuid id PK "資産ID"
+        int category_id FK "カテゴリID"
+        varchar_255 name "資産名"
+        varchar_50 ticker_symbol "ティッカーシンボル"
+        decimal_18_4 quantity "保有数量"
+        decimal_18_2 average_cost "平均取得単価"
+        decimal_18_2 current_price "現在価格"
+        decimal_18_2 current_value "現在評価額"
+        varchar_3 currency "通貨（JPY/USD）"
+        timestamp created_at "作成日時"
+        timestamp updated_at "更新日時"
+    }
+
+    asset_histories {
+        uuid id PK "履歴ID"
+        uuid asset_id FK "資産ID"
+        date record_date "記録日"
+        decimal_18_2 price "その日の価格"
+        decimal_18_2 value "その日の評価額"
+        decimal_18_4 quantity "その日の保有数量"
+        timestamp created_at "作成日時"
+    }
+
+    asset_snapshots {
+        uuid id PK "スナップショットID"
+        date snapshot_date UK "スナップショット日付"
+        decimal_18_2 total_assets "総資産額"
+        decimal_18_2 japanese_stocks "日本株合計"
+        decimal_18_2 us_stocks "米国株合計"
+        decimal_18_2 investment_trusts "投資信託合計"
+        decimal_18_2 cash "現金合計"
+        int holding_count "保有銘柄数"
+        decimal_5_2 yield_rate "利回り（%）"
+        timestamp created_at "作成日時"
+    }
+
+    savings_goals {
+        uuid id PK "目標ID"
+        varchar_100 label "目標ラベル"
+        decimal_18_2 target_amount "目標金額"
+        decimal_18_2 current_amount "現在金額"
+        date target_date "目標達成日"
+        boolean is_active "アクティブフラグ"
+        timestamp created_at "作成日時"
+        timestamp updated_at "更新日時"
+    }
+```
+
+---
+
+## テーブル詳細
+
+### 1. asset_categories（資産カテゴリマスタ）
+
+資産のカテゴリを管理するマスタテーブル。
+
+| カラム名 | データ型 | 制約 | 説明 |
+|---------|---------|------|------|
+| `id` | `SERIAL` | PRIMARY KEY | カテゴリID |
+| `name` | `VARCHAR(50)` | UNIQUE, NOT NULL | カテゴリ名（日本語） |
+| `name_en` | `VARCHAR(50)` | NOT NULL | カテゴリ名（英語） |
+| `color` | `VARCHAR(20)` | NOT NULL | チャート表示色 |
+| `icon` | `VARCHAR(50)` | NULL | アイコン名 |
+
+**初期データ:**
+
+| id | name | name_en | color | icon |
+|----|------|---------|-------|------|
+| 1 | 日本株 | japanese_stocks | indigo | Building2 |
+| 2 | 米国株 | us_stocks | amber | Globe |
+| 3 | 投資信託 | investment_trusts | emerald | TrendingUp |
+| 4 | 現金 | cash | slate | Wallet |
+
+---
+
+### 2. assets（資産テーブル）
+
+個別の資産（銘柄）を管理するテーブル。
+
+| カラム名 | データ型 | 制約 | 説明 |
+|---------|---------|------|------|
+| `id` | `UUID` | PRIMARY KEY, DEFAULT uuid_generate_v4() | 資産ID |
+| `category_id` | `INT` | FOREIGN KEY → asset_categories(id), NOT NULL | カテゴリ |
+| `name` | `VARCHAR(255)` | NOT NULL | 資産名（銘柄名など） |
+| `ticker_symbol` | `VARCHAR(50)` | NULL | ティッカーシンボル |
+| `quantity` | `DECIMAL(18, 4)` | NOT NULL, DEFAULT 0 | 保有数量 |
+| `average_cost` | `DECIMAL(18, 2)` | NULL | 平均取得単価 |
+| `current_price` | `DECIMAL(18, 2)` | NULL | 現在価格 |
+| `current_value` | `DECIMAL(18, 2)` | NULL | 現在評価額 |
+| `currency` | `VARCHAR(3)` | NOT NULL, DEFAULT 'JPY' | 通貨（JPY/USD） |
+| `created_at` | `TIMESTAMP` | NOT NULL, DEFAULT NOW() | 作成日時 |
+| `updated_at` | `TIMESTAMP` | NOT NULL, DEFAULT NOW() | 更新日時 |
+
+**インデックス:**
+- `idx_assets_category_id` ON `category_id`
+
+---
+
+### 3. asset_histories（資産履歴テーブル）
+
+資産の日次価格・評価額履歴を記録するテーブル。
+
+| カラム名 | データ型 | 制約 | 説明 |
+|---------|---------|------|------|
+| `id` | `UUID` | PRIMARY KEY, DEFAULT uuid_generate_v4() | 履歴ID |
+| `asset_id` | `UUID` | FOREIGN KEY → assets(id) ON DELETE CASCADE, NOT NULL | 対象資産 |
+| `record_date` | `DATE` | NOT NULL | 記録日 |
+| `price` | `DECIMAL(18, 2)` | NULL | その日の価格 |
+| `value` | `DECIMAL(18, 2)` | NOT NULL | その日の評価額 |
+| `quantity` | `DECIMAL(18, 4)` | NULL | その日の保有数量 |
+| `created_at` | `TIMESTAMP` | NOT NULL, DEFAULT NOW() | 作成日時 |
+
+**制約:**
+- `UNIQUE (asset_id, record_date)` - 同一資産の同一日に複数レコード不可
+
+**インデックス:**
+- `idx_asset_histories_asset_id` ON `asset_id`
+- `idx_asset_histories_record_date` ON `record_date`
+
+---
+
+### 4. asset_snapshots（資産スナップショットテーブル）
+
+チャート表示用の日次集計データを格納するテーブル。
+
+| カラム名 | データ型 | 制約 | 説明 |
+|---------|---------|------|------|
+| `id` | `UUID` | PRIMARY KEY, DEFAULT uuid_generate_v4() | スナップショットID |
+| `snapshot_date` | `DATE` | UNIQUE, NOT NULL | スナップショット日付 |
+| `total_assets` | `DECIMAL(18, 2)` | NOT NULL | 総資産額 |
+| `japanese_stocks` | `DECIMAL(18, 2)` | NOT NULL, DEFAULT 0 | 日本株合計 |
+| `us_stocks` | `DECIMAL(18, 2)` | NOT NULL, DEFAULT 0 | 米国株合計 |
+| `investment_trusts` | `DECIMAL(18, 2)` | NOT NULL, DEFAULT 0 | 投資信託合計 |
+| `cash` | `DECIMAL(18, 2)` | NOT NULL, DEFAULT 0 | 現金合計 |
+| `holding_count` | `INT` | NOT NULL, DEFAULT 0 | 保有銘柄数 |
+| `yield_rate` | `DECIMAL(5, 2)` | NULL | 利回り（%） |
+| `created_at` | `TIMESTAMP` | NOT NULL, DEFAULT NOW() | 作成日時 |
+
+**インデックス:**
+- `idx_asset_snapshots_snapshot_date` ON `snapshot_date`
+
+**集計ロジック:**
+
+| 表示期間 | 取得方法 |
+|---------|---------|
+| 日次 | 直近30日のデータをそのまま取得 |
+| 月次 | 各月の最終日のデータを抽出 |
+| 年次 | 各年の最終日のデータを抽出 |
+
+---
+
+### 5. savings_goals（貯金目標テーブル）
+
+貯金目標を管理するテーブル。
+
+| カラム名 | データ型 | 制約 | 説明 |
+|---------|---------|------|------|
+| `id` | `UUID` | PRIMARY KEY, DEFAULT uuid_generate_v4() | 目標ID |
+| `label` | `VARCHAR(100)` | NOT NULL | 目標ラベル（例: "目標資産額"） |
+| `target_amount` | `DECIMAL(18, 2)` | NOT NULL | 目標金額 |
+| `current_amount` | `DECIMAL(18, 2)` | NOT NULL, DEFAULT 0 | 現在金額 |
+| `target_date` | `DATE` | NULL | 目標達成日 |
+| `is_active` | `BOOLEAN` | NOT NULL, DEFAULT true | アクティブフラグ |
+| `created_at` | `TIMESTAMP` | NOT NULL, DEFAULT NOW() | 作成日時 |
+| `updated_at` | `TIMESTAMP` | NOT NULL, DEFAULT NOW() | 更新日時 |
+
+---
+
+## フロントエンドとの対応関係
+
+| フロントエンド | DBテーブル/カラム | 説明 |
+|--------------|-----------------|------|
+| `appConfig.savingsGoal.targetAmount` | `savings_goals.target_amount` | 目標金額 |
+| `appConfig.savingsGoal.currentAmount` | `savings_goals.current_amount` | 現在金額 |
+| `appConfig.dashboard.stats.totalAssets` | `asset_snapshots.total_assets` | 総資産額 |
+| `appConfig.dashboard.stats.holdings` | `asset_snapshots.holding_count` | 保有銘柄数 |
+| `appConfig.dashboard.stats.yield` | `asset_snapshots.yield_rate` | 利回り |
+| `mockData.dailyDataRaw` | `asset_snapshots` (日次) | 日次推移 |
+| `mockData.monthlyDataRaw` | `asset_snapshots` (月末抽出) | 月次推移 |
+| `mockData.yearlyDataRaw` | `asset_snapshots` (年末抽出) | 年次推移 |
+| `PortfolioSection` | `asset_snapshots` + `asset_categories` | ポートフォリオ構成 |
+
+---
+
+## DDL（データ定義言語）
+
+```sql
+-- Enable UUID extension
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- Asset categories master table
+CREATE TABLE asset_categories (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(50) UNIQUE NOT NULL,
+    name_en VARCHAR(50) NOT NULL,
+    color VARCHAR(20) NOT NULL,
+    icon VARCHAR(50)
+);
+
+-- Assets table
+CREATE TABLE assets (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    category_id INT NOT NULL REFERENCES asset_categories(id),
+    name VARCHAR(255) NOT NULL,
+    ticker_symbol VARCHAR(50),
+    quantity DECIMAL(18, 4) NOT NULL DEFAULT 0,
+    average_cost DECIMAL(18, 2),
+    current_price DECIMAL(18, 2),
+    current_value DECIMAL(18, 2),
+    currency VARCHAR(3) DEFAULT 'JPY',
+    created_at TIMESTAMP DEFAULT NOW(),
+    updated_at TIMESTAMP DEFAULT NOW()
+);
+
+-- Asset histories table
+CREATE TABLE asset_histories (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    asset_id UUID NOT NULL REFERENCES assets(id) ON DELETE CASCADE,
+    record_date DATE NOT NULL,
+    price DECIMAL(18, 2),
+    value DECIMAL(18, 2) NOT NULL,
+    quantity DECIMAL(18, 4),
+    created_at TIMESTAMP DEFAULT NOW(),
+    UNIQUE (asset_id, record_date)
+);
+
+-- Asset snapshots table
+CREATE TABLE asset_snapshots (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    snapshot_date DATE UNIQUE NOT NULL,
+    total_assets DECIMAL(18, 2) NOT NULL,
+    japanese_stocks DECIMAL(18, 2) DEFAULT 0,
+    us_stocks DECIMAL(18, 2) DEFAULT 0,
+    investment_trusts DECIMAL(18, 2) DEFAULT 0,
+    cash DECIMAL(18, 2) DEFAULT 0,
+    holding_count INT DEFAULT 0,
+    yield_rate DECIMAL(5, 2),
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+-- Savings goals table
+CREATE TABLE savings_goals (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    label VARCHAR(100) NOT NULL,
+    target_amount DECIMAL(18, 2) NOT NULL,
+    current_amount DECIMAL(18, 2) DEFAULT 0,
+    target_date DATE,
+    is_active BOOLEAN DEFAULT true,
+    created_at TIMESTAMP DEFAULT NOW(),
+    updated_at TIMESTAMP DEFAULT NOW()
+);
+
+-- Indexes
+CREATE INDEX idx_assets_category_id ON assets(category_id);
+CREATE INDEX idx_asset_histories_asset_id ON asset_histories(asset_id);
+CREATE INDEX idx_asset_histories_record_date ON asset_histories(record_date);
+CREATE INDEX idx_asset_snapshots_snapshot_date ON asset_snapshots(snapshot_date);
+
+-- Initial data
+INSERT INTO asset_categories (name, name_en, color, icon) VALUES
+('日本株', 'japanese_stocks', 'indigo', 'Building2'),
+('米国株', 'us_stocks', 'amber', 'Globe'),
+('投資信託', 'investment_trusts', 'emerald', 'TrendingUp'),
+('現金', 'cash', 'slate', 'Wallet');
+```
+
+---
+
+## 補足事項
+
+### パフォーマンスについて
+
+- **シングルユーザー前提**: 5年運用で約2,000行程度のため、クエリは瞬時（< 10ms）
+- **インデックス**: 主要な検索条件にインデックスを設定済み
+- **日/月/年の集計**: 日次データのみ保存し、月次・年次はSQLで抽出
+
+### 将来の拡張性
+
+マルチユーザー対応が必要な場合は、以下の変更が必要：
+1. 各テーブルに `user_id` カラムを追加
+2. 複合インデックス `(user_id, snapshot_date)` を作成
+3. 1万ユーザー以上の場合はRedis等のキャッシュを検討


### PR DESCRIPTION
- main.py: FastAPI の title, description, tags を日本語化
- routers.py: 全エンドポイントに summary/description を追加
- schemas.py: 全フィールドに description と example を追加
- database-setup.md: DB セットアップワークフローを追加
- pyproject.toml: Ruff 設定を調整（B008 除外、行長100）